### PR TITLE
Fix intra-notebook hyperlinks (attempt 2)

### DIFF
--- a/four-factor-seeded-logreg.ipynb
+++ b/four-factor-seeded-logreg.ipynb
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Table of contents (click to jump to a section)\n",
+    "### Table of contents (click to jump to a section - doesn't work on Github)\n",
     "[Load and prepare the data](#Load-and-prepare-the-data)  \n",
     "[Select the training data](#Select-the-training-data)  \n",
     "[Select the test data](#Select-the-test-data)  \n",

--- a/four-factor-seeded-logreg.ipynb
+++ b/four-factor-seeded-logreg.ipynb
@@ -32,14 +32,14 @@
    "metadata": {},
    "source": [
     "### Table of contents (click to jump to a section)\n",
-    "[Load and prepare the data](#Step1)  \n",
-    "[Select the training data](#Step2)  \n",
-    "[Select the test data](#Step3)  \n",
-    "[Select and train the model](#Step4)  \n",
-    "[Make predictions](#Step5)  \n",
-    "[Load in the results for 2019 thus far](#Step6)  \n",
-    "[Get accuracy of predictions](#Step7)  \n",
-    "[Fill out visual bracket based on predictions](#Step8)"
+    "[Load and prepare the data](#Load-and-prepare-the-data)  \n",
+    "[Select the training data](#Select-the-training-data)  \n",
+    "[Select the test data](#Select-the-test-data)  \n",
+    "[Select and train the model](#Select-and-train-the-model)  \n",
+    "[Make predictions](#Make-predictions)  \n",
+    "[Load in the results for 2019 thus far](#Load-in-the-results-for-2019-thus-far)  \n",
+    "[Get accuracy of predictions](#Get-accuracy-of-predictions)  \n",
+    "[Fill out visual bracket based on predictions](#Fill-out-visual-bracket-based-on-predictions)"
    ]
   },
   {
@@ -68,13 +68,6 @@
    "source": [
     "# turn off chained assignment warning\n",
     "pd.set_option('mode.chained_assignment', None)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Step1'></a>"
    ]
   },
   {
@@ -576,13 +569,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='Step2'></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Select the training data"
    ]
   },
@@ -613,13 +599,6 @@
     "# shuffle X at the same time as y\n",
     "for year in range(2014, 2020):\n",
     "    X_train[year], y_train[year] = shuffle(X_train[year], y_train[year])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Step3'></a>"
    ]
   },
   {
@@ -1140,13 +1119,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
    "outputs": [],
@@ -1157,13 +1129,6 @@
     "for year in range(2014, 2020):\n",
     "    X_test[year] = tourney[year][deltas].values\n",
     "    y_test[year] = tourney[year]['result'].values\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Step4'></a>"
    ]
   },
   {
@@ -1210,13 +1175,6 @@
     "# fit the models\n",
     "for year in range(2014, 2020):\n",
     "        model[year].fit(X_train[year], y_train[year])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Step5'></a>"
    ]
   },
   {
@@ -1395,13 +1353,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='Step6'></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Load in the results for 2019 thus far"
    ]
   },
@@ -1573,13 +1524,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='Step7'></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Get accuracy of predictions"
    ]
   },
@@ -1641,7 +1585,9 @@
   {
    "cell_type": "code",
    "execution_count": 149,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1677,13 +1623,6 @@
     "    y_pred = tourney[year]['random'][nn]\n",
     "    ll = log_loss(y_true, y_pred)\n",
     "    print(f'{year}: {nc} out of {ng} games correctly predicted ({pct:.1f}%), logloss = {ll:.3f}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Step8'></a>"
    ]
   },
   {


### PR DESCRIPTION
Using just the header text (with hyphens for spaces) (e.g. `(#Load-and-prepare-the-data)`) instead of:
`<a name='Step1'></a>`
or:
`<a id='Step1'></a>`
along with with `(#Step1)`